### PR TITLE
New numpy version compat.

### DIFF
--- a/model.py
+++ b/model.py
@@ -27,7 +27,7 @@ class OpenNsfwModel:
     def build(self, weights_path="open_nsfw-weights.npy",
               input_type=InputType.TENSOR):
 
-        self.weights = np.load(weights_path, encoding="latin1").item()
+        self.weights = np.load(weights_path, encoding="latin1", allow_pickle=True).item()
         self.input_tensor = None
 
         if input_type == InputType.TENSOR:


### PR DESCRIPTION
By standard in newer versions of numpy  `allow_pickle` in `numpy.load` function equals to `False`, so we cannot load weights without setting it to `True`